### PR TITLE
fix: change a way to grab pdf.worker.min

### DIFF
--- a/src/components/Resume/index.js
+++ b/src/components/Resume/index.js
@@ -3,11 +3,7 @@ import { useState, useEffect } from 'react';
 import resumePdf from "../../assets/Resume.pdf";
 import { Document, Page, pdfjs } from "react-pdf";
 
-
-pdfjs.GlobalWorkerOptions.workerSrc = new URL(
-    'pdfjs-dist/build/pdf.worker.min.mjs',
-    import.meta.url,
-).toString();
+pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.mjs`;
 
 
 const Resume = () => {


### PR DESCRIPTION
## Problem 
Heroku deployment worked but PDF can't be loaded. 

## Solution 
I initially used the recommended approach to configure PDF.js worker. See link: https://github.com/wojtekmaj/react-pdf?tab=readme-ov-file#configure-pdfjs-worker

I then changed it to use external cdn: https://github.com/wojtekmaj/react-pdf?tab=readme-ov-file#use-external-cdn
